### PR TITLE
Dependency versions are in fact node-semver ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Type: `Object`
 Dependencies are specified with a simple hash of package name to a semver compatible identifier or URL.
 
 * Key must be a valid [name](#name).
-* Value must be a valid [version](#version), a Git URL, or a URL (inc. tarball and zipball).
+* Value must be a valid [semver range](https://github.com/npm/node-semver#ranges), a Git URL, or a URL (inc. tarball and zipball).
 * Git URLs can be restricted to a reference (revision SHA, branch, or tag) by appending it after a hash, e.g. `https://github.com/owner/package.git#branch`.
 * Value can be an owner/package shorthand, i.e. owner/package. By default, the shorthand resolves to GitHub -> git://github.com/{{owner}}/{{package}}.git. This may be changed in `.bowerrc` [shorthand_resolver](http://bower.io/docs/config/#shorthand-resolver).
 * Local paths may be used as values for local development, but they will be disallowed when registering.


### PR DESCRIPTION
This just codifies Bower's existing behavior in this area.
For example, `bower install 'jquery#1.9.1 - 2'` and `bower install 'bootstrap#9b1a213cf758e1b60e20c59a721a63e13da098f7'` (see https://github.com/twbs/bootstrap/blob/9b1a213cf758e1b60e20c59a721a63e13da098f7/bower.json#L32) already work this way and do the right thing.
CC: @desandro 